### PR TITLE
Problem when you try to access to Laurens Rietveld´s GitHub profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@ body {
 					</p>
 					<a
 							class="btn btn-large btn-primary"
-							href="https://github.com/LaurensRietveld/yasgui" target="_blank">View my profile
+							href="https://github.com/LaurensRietveld" target="_blank">View my profile
 							on GitHub&nbsp;<img style="height: 22px;"
 							src="assets/img/blacktocat.png"></img></a>
 					<a href="http://nl.linkedin.com/pub/laurens-rietveld/a/a87/390"


### PR DESCRIPTION
There is a mistake when you try to access to Laurens Rietveld´s GitHub profile using the  homepage´s button.

The actual link is https://github.com/LaurensRietveld/yasgui, but that page does not exist.

I replaced the link with https://github.com/LaurensRietveld/